### PR TITLE
Add beta3 flag to Scatter instantiation

### DIFF
--- a/src/ScatterUser.ts
+++ b/src/ScatterUser.ts
@@ -26,7 +26,7 @@ export class ScatterUser extends User {
       port: rpcEndpoint.port,
     }
     const rpc = this.rpc
-    this.api = this.scatter.eos(network, Api, { rpc })
+    this.api = this.scatter.eos(network, Api, { rpc, beta3: true })
   }
 
   public async signTransaction(


### PR DESCRIPTION
<!-- PLEASE FILL OUT THE FOLLOWING MARKDOWN TEMPLATE -->
<!-- PR title alone should be sufficient to understand changes. -->

## Change Description
<!-- Describe your changes, their justification, AND their impact. Reference issues or pull requests where possible (use '#XX' or 'GH-XX' where XX is the issue or pull request number). -->
ScatterJS required a `beta3` flag set to true during instantiation in order to correctly integrate with the latest version of eosjs `20.0.0`, formerly known as `20.0.0-beta3`

## API Changes
- [ ] API Changes
<!-- checked [x] = API changes; unchecked [ ] = no changes, ignore this section -->
<!-- If this PR introduces API changes, please describe the changes here. What will developers need to know before upgrading to this version? -->


## Documentation Additions
- [ ] Documentation Additions
<!-- checked [x] = Documentation changes; unchecked [ ] = no changes, ignore this section -->
<!-- Describe what must be added to the documentation after merge. -->
