### PR TITLE
Pass custom error messages (like assertion errors)

### DIFF
--- a/src/ScatterUser.ts
+++ b/src/ScatterUser.ts
@@ -46,7 +46,7 @@ export class ScatterUser extends User {
       return this.returnEosjsTransaction(broadcast, completedTransaction)
     } catch (e) {
       throw new UALScatterError(
-        'Unable to sign the given transaction',
+        e.message || 'Unable to sign the given transaction',
         UALErrorType.Signing,
         e)
     }


### PR DESCRIPTION
## Change Description
The original error message should be used when signing fails. It is possible to access it via cause, but it should also be in the UALScatterError message

## API Changes
---

## Documentation Additions
---
